### PR TITLE
add type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,70 @@
+type level = "debug" | "info" | "warn" | "error";
+
+type setting = "bold" | "italic" | "dim" | "underscore" | "reverse" | "strikethrough";
+
+type color = "black" | "red" | "green" | "yellow" | "blue" | "magenta" | "cyan" | "white";
+
+type ticketObject = {
+    font?: color,
+    bg?: color,
+}
+
+type settingObject = {
+    [key in setting]?: boolean;
+};
+
+declare class Logger {
+    command: string;
+    lastCommand: string;
+    level: any;
+    noColor: boolean;
+
+    setLevel(level: level): void;
+
+    setLevelNoColor(): void;
+
+    setLevelColor(): void;
+
+    isLevelValid(level: level): boolean;
+
+    isAllowedLevel(level: level): boolean;
+
+    checkSetting(setting: settingObject): string;
+
+    joint(): Logger;
+    
+    color(ticket: color): Logger;
+    
+    bgColor(ticket: color): Logger;
+    
+    bold(): Logger;
+    
+    dim(): Logger;
+    
+    underscore(): Logger;
+    
+    strikethrough(): Logger;
+    
+    reverse(): Logger;
+    
+    italic(): Logger;
+    
+    fontColorLog(ticket: color, text: string, setting?: settingObject): void;
+    
+    bgColorLog(ticket: color, text: string, setting?: settingObject): void;
+    
+    colorLog(ticketObj: ticketObject, text: string, setting?: settingObject): void;
+
+    log(...args: any[]): Logger;
+
+    error(...args: any[]): void;
+
+    warn(...args: any[]): void;
+
+    info(...args: any[]): void;
+
+    debug(...args: any[]): void;
+}
+
+declare const logger: Logger;
+export = logger;


### PR DESCRIPTION
Hey 👋 

I added a `.d.ts` file with typescript declarations that export with your module.

Because you are [exporting a class instance](https://github.com/tigercosmos/node-color-log/blob/bc1ba04ffe8997206d47ef427259b7c0faeb320d/index.js#L304), typescript users will need to use the `--esModuleInterop` flag (which is common)

I personally tested that these types work for all use cases, but I can add an automated test to check that typings compile if you wish ☺️ 

this pr closes #15 