### PR TITLE
add success option and increase label contrast

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export type LEVEL = "debug" | "info" | "warn" | "error" | "disable";
+export type LEVEL = "debug" | "info" | "warn" | "error" | "disable" | "success";
 
 export type SETTING = "bold" | "italic" | "dim" | "underscore" | "reverse" | "strikethrough";
 
@@ -68,6 +68,8 @@ declare class Logger {
     info(...args: any[]): void;
 
     debug(...args: any[]): void;
+
+    success(...args: any[]): void;
 }
 
 declare const logger: Logger;

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const CONFIG = {
 };
 
 // Sequence of levels is important.
-const LEVELS = ["debug", "info", "warn", "error", "disable"];
+const LEVELS = ["debug", "info", "warn", "error", "disable", "success"];
 
 class Logger {
     constructor() {
@@ -293,6 +293,23 @@ class Logger {
                 .bgColor('cyan').log("[DEBUG]").joint()
                 .log(' ').joint()
                 .color('cyan')
+                .log(...args);
+        }
+    }
+
+    success(...args) {
+        if (!this.isAllowedLevel("success"))
+            return;
+
+        if (this.noColor) {
+            const d = this.getDate();
+            this.log(d, " [SUCCESS] ", ...args);
+        } else {
+            const d = this.getDate();
+            this.log(d + " ").joint()
+                .bgColor('green').log("[SUCCESS]").joint()
+                .log(' ').joint()
+                .color('green')
                 .log(...args);
         }
     }

--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ class Logger {
         } else {
             const d = this.getDate();
             this.log(d + " ").joint()
-                .bgColor('yellow').log('[WARN]').joint()
+                .bgColor('yellow').color('black').log('[WARN]').joint()
                 .log(" ").joint()
                 .color('yellow').log(...args);
         }
@@ -274,7 +274,7 @@ class Logger {
         } else {
             const d = this.getDate();
             this.log(d + " ").joint()
-                .bgColor('green').log('[INFO]').joint()
+                .bgColor('green').color('black').log('[INFO]').joint()
                 .log(" ").joint()
                 .color('green').log(...args);
         }
@@ -290,7 +290,7 @@ class Logger {
         } else {
             const d = this.getDate();
             this.log(d + " ").joint()
-                .bgColor('cyan').log("[DEBUG]").joint()
+                .bgColor('cyan').color('black').log("[DEBUG]").joint()
                 .log(' ').joint()
                 .color('cyan')
                 .log(...args);
@@ -307,7 +307,7 @@ class Logger {
         } else {
             const d = this.getDate();
             this.log(d + " ").joint()
-                .bgColor('green').log("[SUCCESS]").joint()
+                .bgColor('green').color('black').log("[SUCCESS]").joint()
                 .log(' ').joint()
                 .color('green')
                 .log(...args);

--- a/test2.js
+++ b/test2.js
@@ -9,3 +9,4 @@ logger.error('error show');
 logger.warn('warn show');
 logger.info('info show');
 logger.debug('debug will not show');
+logger.success('success show');


### PR DESCRIPTION
Thank you for this awesome helper. I am missing a `success` option and suggesting this with this pull request. 

Also I am having troubles reading white text on light background, so I am also suggesting to increase the contrast for the labels (except `error`). 

<img width="480" alt="image" src="https://user-images.githubusercontent.com/46668283/159117232-77c1d25d-4936-42f4-83af-fa443b84e651.png">

<img width="480" alt="image" src="https://user-images.githubusercontent.com/46668283/159117247-e901c19b-d3fd-4d35-8dfb-320abea094a1.png">
