### PR TITLE
Add error catching to JSON stringify

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,11 @@ class Logger {
             if (typeof arg === "string") {
                 this.command += arg;
             } else {
-                this.command += JSON.stringify(arg);
+                try {
+                    this.command += JSON.stringify(arg);
+                } catch {
+                    this.command += arg;
+                }
             }
             if (args.length > 1 && idx < args.length - 1) {
                 this.command += " ";

--- a/test3.js
+++ b/test3.js
@@ -1,0 +1,6 @@
+const logger = require('./index');
+
+const object = {}
+object.x = object
+// $ LOGGER=info node test3.js
+logger.info("Should print \"[object Object]\" and not throw an error:",object);


### PR DESCRIPTION
Currently the logger throws an error when attempting to print an object with a circular structure. For example:
```js
const object = {}
object.x = object
```
Or for a non trivial example see an axios response. To fix this I am just catching when the JSON.stringify fails and falling back implicitly to the toString method.