### PR TITLE
Named loggers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,8 @@ declare class Logger {
 
     setLevel(level: LEVEL): void;
 
+    createNamedLogger(name: string): Logger;
+
     setLevelNoColor(): void;
 
     setLevelColor(): void;

--- a/index.js
+++ b/index.js
@@ -85,7 +85,11 @@ class Logger {
             if (typeof arg === "string") {
                 this.command += arg;
             } else {
-                this.command += JSON.stringify(arg);
+                try {
+                    this.command += JSON.stringify(arg);
+                } catch {
+                    this.command += arg;
+                }
             }
             if (args.length > 1 && idx < args.length - 1) {
                 this.command += " ";

--- a/index.js
+++ b/index.js
@@ -36,11 +36,13 @@ const CONFIG = {
 const LEVELS = ["success", "debug", "info", "warn", "error", "disable"];
 
 class Logger {
-    constructor() {
+    constructor(name) {
         // Current command
         this.command = '';
         // Last line
         this.lastCommand = '';
+
+        this.name = name || ""
 
         // set level from env
         const level = process.env.LOGGER;
@@ -51,6 +53,10 @@ class Logger {
         this.noColor = false;
 
         this._getDate = () => (new Date()).toISOString();
+    }
+
+    createNamedLogger(name){
+        return new Logger(name)
     }
 
     setLevel(level) {
@@ -85,11 +91,7 @@ class Logger {
             if (typeof arg === "string") {
                 this.command += arg;
             } else {
-                try {
-                    this.command += JSON.stringify(arg);
-                } catch {
-                    this.command += arg;
-                }
+                this.command += JSON.stringify(arg);
             }
             if (args.length > 1 && idx < args.length - 1) {
                 this.command += " ";
@@ -130,8 +132,12 @@ class Logger {
         this._getDate = callback;
     }
 
-    getDate() {
-        return this._getDate();
+    getPrefix() {
+        if(this.name) {
+            return `${this._getDate()} [${this.name}]`;
+        } else {
+            return this._getDate();
+        }
     }
 
     color(ticket) {
@@ -241,10 +247,10 @@ class Logger {
             return;
 
         if (this.noColor) {
-            const d = this.getDate();
+            const d = this.getPrefix();
             this.log(d, " [ERROR] ", ...args);
         } else {
-            const d = this.getDate();
+            const d = this.getPrefix();
             this.log(d + " ").joint()
                 .bgColor('red').log('[ERROR]').joint()
                 .log(" ").joint()
@@ -257,10 +263,10 @@ class Logger {
             return;
 
         if (this.noColor) {
-            const d = this.getDate();
+            const d = this.getPrefix();
             this.log(d, " [WARN] ", ...args);
         } else {
-            const d = this.getDate();
+            const d = this.getPrefix();
             this.log(d + " ").joint()
                 .bgColor('yellow').color('black').log('[WARN]').joint()
                 .log(" ").joint()
@@ -273,10 +279,10 @@ class Logger {
             return;
 
         if (this.noColor) {
-            const d = this.getDate();
+            const d = this.getPrefix();
             this.log(d, " [INFO] ", ...args);
         } else {
-            const d = this.getDate();
+            const d = this.getPrefix();
             this.log(d + " ").joint()
                 .bgColor('green').color('black').log('[INFO]').joint()
                 .log(" ").joint()
@@ -289,10 +295,10 @@ class Logger {
             return;
 
         if (this.noColor) {
-            const d = this.getDate();
+            const d = this.getPrefix();
             this.log(d, " [DEBUG] ", ...args);
         } else {
-            const d = this.getDate();
+            const d = this.getPrefix();
             this.log(d + " ").joint()
                 .bgColor('cyan').color('black').log("[DEBUG]").joint()
                 .log(' ').joint()
@@ -306,10 +312,10 @@ class Logger {
             return;
 
         if (this.noColor) {
-            const d = this.getDate();
+            const d = this.getPrefix();
             this.log(d, " [SUCCESS] ", ...args);
         } else {
-            const d = this.getDate();
+            const d = this.getPrefix();
             this.log(d + " ").joint()
                 .bgColor('green').color('black').log("[SUCCESS]").joint()
                 .log(' ').joint()

--- a/test3.js
+++ b/test3.js
@@ -1,0 +1,6 @@
+const logger = require('./index');
+
+const object = {}
+object.x = object
+// $ LOGGER=info node test3.js
+logger.info("Should print \"[object Object]\" and not throw an error:",object);

--- a/test4.js
+++ b/test4.js
@@ -1,0 +1,12 @@
+const logger = require('./index').createNamedLogger("Test 4");
+
+// $ LOGGER=info node test2.js
+logger.log('****************************************');
+logger.log('*** Test Environment Variable LOGGER ***');
+logger.log('****************************************');
+logger.log("LOGGER=info, debug level will not show");
+logger.error('error show');
+logger.warn('warn show');
+logger.info('info show');
+logger.debug('debug will not show');
+logger.success('success show');


### PR DESCRIPTION
This PR adds the ability to name a specific logger, with a name that is affixed to the prefixed when it is logging. This feature is useful for when working in large projects to name the loggers of specific services within the project to better understand where all the logs are coming from.
In addition to this change I renamed "getDate" to "getPrefix" to better match its new behavoir.
This PR also includes the changes from PR #25 but I can remove those changes from this branch if needed. This PR does not break any existing behavior, and simply adds this new feature as an additional use case.
The new additional usage would be as follows:
```js
const logger = require('node-color-log').createNamedLogger("Test 4");
logger.error('error show');
logger.warn('warn show');
logger.info('info show');
```
With the output looking like this:
![image](https://user-images.githubusercontent.com/13110124/185719502-bd25db88-a432-4731-9566-0bb7cbc34720.png)
