### PR TITLE
Add import statement for Stream in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+import { Stream } from "stream";
 declare namespace types {
     export type LEVEL = "debug" | "info" | "warn" | "error" | "disable" | "success";
 


### PR DESCRIPTION
FIX ERROR

yarn run v1.22.19
$ tsc && tsc-alias
node_modules/node-color-log/index.d.ts:28:26 - error TS2304: Cannot find name 'Stream'.

28     setLogStream(stream: Stream): Logger;
                            ~~~~~~


Found 1 error in node_modules/node-color-log/index.d.ts:28

error Command failed with exit code 2.