### PR TITLE
Compatibility to cf workers

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ class Logger {
         this.name = name || ""
 
         // set level from env
-        const level = process.env.LOGGER;
+        const level = typeof process !== 'undefined' ? process.env.LOGGER : undefined;
         if (this.isLevelValid(level)) {
             this.level = level;
         }


### PR DESCRIPTION
without node compatibility, trying to access `process` will result in build issues. Checking if process is available will make builds work fine.